### PR TITLE
Make FileDriver.py the "runner" 

### DIFF
--- a/CallJava.py
+++ b/CallJava.py
@@ -1,11 +1,10 @@
 import sys
+import json
 try:
     import org.apache.hadoop.io.Text as Text;
     import java.lang.System as System
-    from com.xhaus.jyson import JysonCodec as json
 except ImportError: #cpython
     Text = str
-    import json
 
 def map(key, value, context):
     try:
@@ -36,7 +35,3 @@ def map(key, value, context):
     
 #def reduce(key, values, context):
 #    context.write(key, Text())
-
-if __name__ == "__main__":
-    from FileDriver import map_reduce
-    map_reduce(sys.modules[__name__], sys.argv[1])

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@ Querying json with java is too much work. Doing in Python allows for easier loca
 
 Idea is that one keeps boilerplate in java and does important things in python.
 
-To test python map/reduce one can use FileDriver.py in __main__
-For example:
+To test scripts, use PythonDriver.py:
 ```
-python CallJava.py log > log.out
+python PythonDriver.py CallJava.py log > log.out
 ```
-where log is a newline-separated json dump. See CallJava.py for an example a script runnable with normal python and jyson.
+where log is a newline-separated json dump. See CallJava.py for an example mapreduce job with normal python and jyson.
 
 
 =Packaging
-Python script gets wrapped into driver.jar which also contains HDFSDriver and HBaseDriver. Choose one depending on if you are doing a map of a hdfs or hbase.
+Python script gets wrapped into driver.jar with the HBaseDriver.
 
 To process files do:
 ````

--- a/scripts/anr.py
+++ b/scripts/anr.py
@@ -1,4 +1,5 @@
 #make hadoop ARGS="telemetry anr 20130313 20130313 yyyyMMdd" SCRIPT=scripts/anr.py
+#python FileDriver.py scripts/anr.py test.data
 import sys
 import json
 try:
@@ -12,7 +13,3 @@ def map(key, value, context):
         return
     outkey = Text(value)
     context.write(outkey, Text())
-    
-if __name__ == "__main__":
-    from FileDriver import map_reduce
-    map_reduce(sys.modules[__name__], sys.argv[1])


### PR DESCRIPTION
So that each mapreduce script doesn't have to have the stubs which load FileDriver.
