### PR TITLE
Despite this being called the "combiner" branch, this does everything except actually implement a combiner

### DIFF
--- a/FileDriver.py
+++ b/FileDriver.py
@@ -1,47 +1,63 @@
 defaultglobals = dict(globals())
 
-import sys
-
 class LocalContext:
-    def __init__(self, map_only = False):
+    def __init__(self):
         self.result = {}
-        self.map_only = map_only
 
     def write(self, key, value):
-        if self.map_only:
-            print "%s %s" % (key, value)
-            return
-        try:
-            self.result[key].append(value)
-        except KeyError:
-            self.result[key] = [value]
+        self.result.setdefault(key, []).append(value)
 
-    def dump(self):
-        for key, values in self.result.iteritems():
+    def __iter__(self):
+        for k, values in self.result.iteritems():
             for v in values:
-                print "%s %s" % (key, v)
+                yield k, v
+
+# By default, if the job has a reduce function, we want to print both the key and the value.
+# If no reduction is happening, users usually don't care about the key.
+def outputwithkey(rlist):
+    for k, v in rlist:
+        print "%s,%s" % (k, v)
+
+def outputnokey(rlist):
+    for k, v in rlist:
+        print v
 
 def map_reduce(module, fd):
     reducefunc = getattr(module, 'reduce', None)
+    mapfunc = getattr(module, 'map')
 
-    context = LocalContext(reducefunc == None)
+    context = LocalContext()
 
+    # We make fake keys by keeping track of the file offset from the incoming
+    # file.
     total = 0;
-    while True:
-        l = fd.readline()
-        length = len(l)
-        total += length
-        if length == 0:
-            break
-        getattr(module, 'map')(str(total), l, context)
+    for line in fd:
+        if len(line) == 0:
+            continue
+        mapfunc(str(total), line, context)
+        total += len(line)
 
-    reduced_context = LocalContext()
-    for key, values in context.result.iteritems():
-        reducefunc(key, values, reduced_context)
-    reduced_context.dump()
+    if reducefunc:
+        reduced_context = LocalContext()
+        for key, values in context.result.iteritems():
+            module.reduce(key, values, reduced_context)
+        context = reduced_context
+
+    if hasattr(module, 'output'):
+        outputfunc = module.output
+    elif reducefunc:
+        outputfunc = outputwithkey
+    else:
+        outputfunc = outputnokey
+
+    outputfunc(iter(context))
     
 if __name__ == '__main__':
-    import imp
+    import imp, sys
+
+    if len(sys.argv) != 3:
+        print >>sys.stderr, "Usage: FileDriver.py <jobscript.py> <input.data or ->"
+        sys.exit(1)
 
     modulepath, filepath = sys.argv[1:]
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ SCRIPT=scripts/CallJava.py
 all: driver.jar
 
 run: driver.jar
-	java -cp driver.jar:$(CP) taras.$(TASK)
+	java -cp driver.jar:$(CP) org.mozilla.pydoop.$(TASK)
 
 hadoop: driver.jar
 #	-hadoop fs -rmr /user/tglek/output
-	time hadoop jar $< taras.$(TASK) -libjars $(subst :,$(comma),$(HADOOP_CLASSPATH)) $(ARGS)
+	time hadoop jar $< org.mozilla.pydoop.$(TASK) -libjars $(subst :,$(comma),$(HADOOP_CLASSPATH)) $(ARGS)
 
 driver.jar: out/CallJava.py $(JAVA_SOURCE)
 	javac -Xlint:deprecation -d out  -cp $(CP) $(JAVA_SOURCE)

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ export HADOOP_USER_CLASSPATH_FIRST="true"
 export HADOOP_CLASSPATH=jython-standalone-2.7-b1.jar:akela-0.5-SNAPSHOT.jar
 CP=$(HADOOP_CLASSPATH):$(HBASE_CP)
 comma:=,
-JAVA_SOURCE=PythonWrapper.java HBaseDriver.java
+JAVA_SOURCE=$(addprefix org/mozilla/pydoop/,PythonWrapper.java TypeWritable.java HBaseDriver.java)
 TASK=HBaseDriver
 ARGS=input output
-SCRIPT=CallJava.py
+SCRIPT=scripts/CallJava.py
 all: driver.jar
 
 run: driver.jar
@@ -22,7 +22,7 @@ hadoop: driver.jar
 	time hadoop jar $< taras.$(TASK) -libjars $(subst :,$(comma),$(HADOOP_CLASSPATH)) $(ARGS)
 
 driver.jar: out/CallJava.py $(JAVA_SOURCE)
-	javac  -Xlint:deprecation -d out  -cp $(CP) $(JAVA_SOURCE)
+	javac -Xlint:deprecation -d out  -cp $(CP) $(JAVA_SOURCE)
 	jar -cvf $@ -C out .
 
 out/CallJava.py: $(SCRIPT)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ HBASE_CP = $(subst $(SPACE),:,$(wildcard $(HBASE_PATH)/*.jar) $(wildcard $(HBASE
 #javac -classpath   HBaseDriver.java  -d out  -Xlint:deprecation  && jar -cvf taras.jar -C out/ . 
 export HADOOP_USER_CLASSPATH_FIRST="true"
 # this will need to change once more jars are added
-export HADOOP_CLASSPATH=jython-standalone-2.7-b1.jar:akela-0.5-SNAPSHOT.jar
+export HADOOP_CLASSPATH=jython-standalone-2.7-b1.jar:akela-0.5-SNAPSHOT.jar:jyson-1.0.2.jar
 CP=$(HADOOP_CLASSPATH):$(HBASE_CP)
 comma:=,
 JAVA_SOURCE=$(addprefix org/mozilla/pydoop/,PythonWrapper.java TypeWritable.java HBaseDriver.java)
@@ -34,3 +34,4 @@ out/CallJava.py: $(SCRIPT)
 download:
 	wget -c http://repo1.maven.org/maven2/org/python/jython-standalone/2.7-b1/jython-standalone-2.7-b1.jar -O jython-standalone-2.7-b1.jar
 	wget -c http://people.mozilla.org/~bsmedberg/akela-0.5-SNAPSHOT.jar -O akela-0.5-SNAPSHOT.jar
+	wget -c http://people.mozilla.org/~tglek/jyson-1.0.2.jar -O jyson-1.0.2.jar

--- a/org/mozilla/pydoop/HBaseDriver.java
+++ b/org/mozilla/pydoop/HBaseDriver.java
@@ -39,8 +39,7 @@ import org.python.core.PyObject;
 import org.python.core.PyIterator;
 
 public class HBaseDriver extends Configured implements Tool {
-  static PyObject mapfunc = PythonWrapper.get("map");
-  static PyObject reducefunc = PythonWrapper.get("reduce");
+  static PythonWrapper module = new PythonWrapper("CallJava.py");
 
   public static class WritableIterWrapper extends PyIterator
   {
@@ -84,7 +83,7 @@ public class HBaseDriver extends Configured implements Tool {
           new String(value_bytes),
           new ContextWrapper(context)
       };
-      mapfunc._jcall(jparams);
+      module.getFunction("map")._jcall(jparams);
     }
   }
 
@@ -96,7 +95,7 @@ public class HBaseDriver extends Configured implements Tool {
             new WritableIterWrapper(values.iterator()),
             new ContextWrapper(context)
         };
-        reducefunc._jcall(jparams);
+        module.getFunction("reduce")._jcall(jparams);
     }
   }
 
@@ -142,8 +141,10 @@ public class HBaseDriver extends Configured implements Tool {
     
     //    job.setOutputFormatClass(NullOutputFormat.class);   // because we aren't emitting anything from mapper
     job.setReducerClass(MyReducer.class);    // reducer class
+
+    boolean maponly = module.getFunction("reduce") == null;
     // set below to 0 to do a map-only job
-    job.setNumReduceTasks(reducefunc != null ? 1 : 0 );    // at least one, adjust as required
+    job.setNumReduceTasks(maponly ? 0 : 4 );    // at least one, adjust as required
 
 
     return job.waitForCompletion(true) ? 0 : 1;

--- a/org/mozilla/pydoop/HBaseDriver.java
+++ b/org/mozilla/pydoop/HBaseDriver.java
@@ -13,7 +13,6 @@ import com.mozilla.util.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
@@ -122,14 +121,13 @@ public class HBaseDriver extends Configured implements Tool {
     List<Pair<String,String>> columns = new ArrayList<Pair<String,String>>(); // family:qualifier
     columns.add(new Pair<String,String>("data", "json"));
     Scan[] scans = MultiScanTableMapReduceUtil.generateBytePrefixScans(startCal, endCal, dateFormat,columns,500, false);
-    //    MultiScanTableMapReduceUtil.initMultiScanTableMapperJob(TABLE_NAME, scans, TelemetryInvalidCountsMapper.class, Text.class, Text.class, job);
 
     MultiScanTableMapReduceUtil.initMultiScanTableMapperJob(
                                           args[0],        // input HBase table name
                                           scans,             // Scan instance to control CF and attribute selection
                                           MyMapper.class,   // mapper
-                                          Text.class,             // mapper output key
-                                          Text.class,             // mapper output value
+                                          TypeWritable.class,             // mapper output key
+                                          TypeWritable.class,             // mapper output value
                                           job);
     
     //    job.setOutputFormatClass(NullOutputFormat.class);   // because we aren't emitting anything from mapper

--- a/org/mozilla/pydoop/PythonWrapper.java
+++ b/org/mozilla/pydoop/PythonWrapper.java
@@ -1,19 +1,55 @@
 package org.mozilla.pydoop;
+import org.python.util.PythonInterpreter;
 import org.python.core.PyObject;
 import org.python.core.PySystemState;
 import org.python.core.Py;
 
+import java.io.InputStream;
+
 public class PythonWrapper {
-  private static PyObject pythonModule;
-  public static PyObject get(String attr) {
-    if (pythonModule == null) {
-      PyObject importer = new PySystemState().getBuiltins().__getitem__(Py.newString("__import__"));
-      pythonModule = importer.__call__(Py.newString("CallJava"));
+  private PythonInterpreter interp;
+
+  public static class JSONImporter extends PyObject {
+    public static final String JSON_IMPORT_PATH_ENTRY = "__jsonpath__";
+
+    public PyObject __call__(PyObject args[], String keywords[]) {
+      if (args[0].toString().endsWith(JSON_IMPORT_PATH_ENTRY)) {
+	return this;
+      }
+      throw Py.ImportError("unable to handle");
     }
-    try {
-      return pythonModule.__getattr__(attr);
-    } catch(Exception e) {
-      return null;
+
+    public PyObject find_module(String name) {
+      if (!name.equals("json")) {
+	return Py.None;
+      }
+
+      return this;
     }
+
+    public PyObject load_module(String name) {
+      PyObject mod = org.python.core.imp.importName("com.xhaus.jyson.JysonCodec", true);
+      return mod.__getattr__("xhaus").__getattr__("jyson").__getattr__("JysonCodec");
+    }
+
+    public String toString() {
+      return this.getType().toString();
+    }
+  }
+
+  PythonWrapper(String pathname) {
+    interp = new PythonInterpreter();
+
+    // Use an import hook so that "import json" uses Jyson instead of the very
+    // slow builtin module.
+    interp.getSystemState().path.insert(0, Py.newString(JSONImporter.JSON_IMPORT_PATH_ENTRY));
+    interp.getSystemState().path_hooks.insert(0, new JSONImporter());
+
+    // Get the pathname off of the classpath
+    InputStream pythonstream = this.getClass().getResourceAsStream("/" + pathname);
+    interp.execfile(pythonstream, pathname);
+  }
+  public PyObject getFunction(String name) {
+    return interp.get(name.intern());
   }
 }

--- a/org/mozilla/pydoop/PythonWrapper.java
+++ b/org/mozilla/pydoop/PythonWrapper.java
@@ -1,4 +1,4 @@
-package taras;
+package org.mozilla.pydoop;
 import org.python.core.PyObject;
 import org.python.core.PySystemState;
 import org.python.core.Py;

--- a/org/mozilla/pydoop/TypeWritable.java
+++ b/org/mozilla/pydoop/TypeWritable.java
@@ -154,4 +154,11 @@ public class TypeWritable implements WritableComparable
   public int hashCode() {
     return value.hashCode();
   }
+
+  public String toString() {
+    if (value == null) {
+      return "null";
+    }
+    return value.toString();
+  }
 }

--- a/org/mozilla/pydoop/TypeWritable.java
+++ b/org/mozilla/pydoop/TypeWritable.java
@@ -59,6 +59,10 @@ public class TypeWritable implements WritableComparable
     throw Py.TypeError("Expected int/float/str/tuple");
   }
 
+  public TypeWritable()
+  {
+  }
+
   public TypeWritable(PyObject obj)
   {
     CheckType(obj);

--- a/org/mozilla/pydoop/TypeWritable.java
+++ b/org/mozilla/pydoop/TypeWritable.java
@@ -1,0 +1,153 @@
+package org.mozilla.pydoop;
+
+import org.python.core.PyObject;
+import org.python.core.PyInteger;
+import org.python.core.PyLong;
+import org.python.core.PyFloat;
+import org.python.core.PyString;
+import org.python.core.PyTuple;
+import org.python.core.Py;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import java.lang.AssertionError;
+
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.io.WritableUtils;
+
+/**
+ * This class is a Hadoop Writable which is capable of reflecting a defined subset of Python
+ * objects as hadoop keys or values.
+ *
+ * The python types representable by this interface are:
+ * - None
+ * - int/long
+ * - float (java double)
+ * - string
+ * - and tuples of the above types
+ */
+public class TypeWritable implements WritableComparable
+{
+  static final byte TYPE_NONE = 0;
+  static final byte TYPE_INT = 1;
+  static final byte TYPE_FLOAT = 2;
+  static final byte TYPE_STRING = 3;
+  static final byte TYPE_TUPLE = 4;
+
+  public PyObject value;
+
+  private static void CheckType(PyObject obj)
+  {
+    if (obj == Py.None) {
+      return;
+    }
+    if (obj instanceof PyInteger ||
+	obj instanceof PyLong ||
+	obj instanceof PyFloat ||
+	obj instanceof PyString) {
+      return;
+    }
+    if (obj instanceof PyTuple) {
+      for (PyObject inner : ((PyTuple)obj).getArray()) {
+	CheckType(inner);
+      }
+      return;
+    }
+
+    throw Py.TypeError("Expected int/float/str/tuple");
+  }
+
+  public TypeWritable(PyObject obj)
+  {
+    CheckType(obj);
+    value = obj;
+  }
+
+  private static void WriteType(DataOutput out, PyObject obj) throws IOException
+  {
+    if (obj == Py.None) {
+      out.writeByte(TYPE_NONE);
+      return;
+    }
+
+    if (obj instanceof PyInteger ||
+	obj instanceof PyLong) {
+      out.writeByte(TYPE_INT);
+      WritableUtils.writeVLong(out, obj.asLong());
+      return;
+    }
+
+    if (obj instanceof PyFloat) {
+      out.writeByte(TYPE_FLOAT);
+      out.writeDouble(obj.asDouble());
+      return;
+    }
+
+    if (obj instanceof PyString) {
+      out.writeByte(TYPE_STRING);
+      out.writeUTF(obj.asString());
+      return;
+    }
+
+    if (obj instanceof PyTuple) {
+      out.writeByte(TYPE_TUPLE);
+      WritableUtils.writeVInt(out, obj.__len__());
+      for (int i = 0; i < obj.__len__(); ++i) {
+	WriteType(out, obj.__getitem__(i));
+      }
+    }
+
+    throw new AssertionError("Unexpected type");
+  }
+
+  public void write(DataOutput out) throws IOException
+  {
+    WriteType(out, value);
+  }
+
+
+  private static PyObject ReadObject(DataInput in) throws IOException
+  {
+    byte type = in.readByte();
+    switch (type) {
+    case TYPE_NONE:
+      return Py.None;
+    case TYPE_INT: {
+      long v = WritableUtils.readVLong(in);
+      if (v > Integer.MAX_VALUE || v < Integer.MIN_VALUE) {
+	return new PyLong(v);
+      }
+      else {
+	return new PyInteger((int) v);
+      }
+    }
+    case TYPE_FLOAT:
+      return new PyFloat(in.readDouble());
+    case TYPE_STRING:
+      return new PyString(in.readUTF());
+    case TYPE_TUPLE:
+      int l = WritableUtils.readVInt(in);
+      PyObject[] objs = new PyObject[l];
+      for (int i = 0; i < l; ++i) {
+	objs[i] = ReadObject(in);
+      }
+      return new PyTuple(objs);
+    }
+    throw new AssertionError("Unexpected type value");
+  }
+
+  public void readFields(DataInput in) throws IOException
+  {
+    value = ReadObject(in);
+  }
+
+  public int compareTo(Object other) {
+    return value.__cmp__(((TypeWritable) other).value);
+  }
+
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/scripts/CallJava.py
+++ b/scripts/CallJava.py
@@ -30,8 +30,7 @@ def map(key, value, context):
         pass
 
     if record:
-        outkey = Text(value)
-        context.write(outkey, Text())
+        context.write(key, value)
     
 #def reduce(key, values, context):
 #    context.write(key, Text())

--- a/scripts/anr.py
+++ b/scripts/anr.py
@@ -8,8 +8,9 @@ try:
 except ImportError: #cpython
     Text = str
 
+# This mapper is just a filter: only records which have an android hang report
+# are included in the result.
 def map(key, value, context):
     if value.find("androidANR") == -1:
         return
-    outkey = Text(value)
-    context.write(outkey, Text())
+    context.write(key, value)

--- a/scripts/osdistribution.py
+++ b/scripts/osdistribution.py
@@ -1,8 +1,11 @@
 # mapreduce job to count the distribution of OS data
 
 import json
+import random
 
 def map(k, v, cx):
+    if random.random() > 0.05:
+        return
     j = json.loads(v)
     os = j['info']['OS']
     cx.write(os, 1)

--- a/scripts/osdistribution.py
+++ b/scripts/osdistribution.py
@@ -1,0 +1,11 @@
+# mapreduce job to count the distribution of OS data
+
+import json
+
+def map(k, v, cx):
+    j = json.loads(v)
+    os = j['info']['OS']
+    cx.write(os, 1)
+
+def reduce(k, vlist, cx):
+    cx.write(k, sum(vlist))


### PR DESCRIPTION
Present in this PR:
- Implement "TypeWritable" which efficiently wraps python strings, ints, floats, and tuples of these.
- Start using jyson as a drop-in replacement for the jython "json" module which performs horribly.
- Implement working reducers
- Implement a final combiner which takes the input from multiple reducers and combines it into a single result file on the local machine.

This change has been tested against telemetry data on mango-gw and works.

Next steps:
- Implement the combiner
- Have TypeWritable implement RawComparator for extra speed
- Do some additional type checking in the python driver for better debugging before deployment
- Make the output serialization of tuples produce excel-tab CSV format
- Allow scripts to customize their output (already implemented in python driver, sorta)
- Change the dispatch mechanism to include all of "scripts" in the JAR file and select which script to run dynamically. Allow importing of utility modules i.e. "combiner = pydoop.countcombine; reduce = pydoop.countreduce"
