### PR TITLE
Package all the scripts in driver.jar and select which one to run at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ hadoop: driver.jar
 #	-hadoop fs -rmr /user/tglek/output
 	time hadoop jar $< org.mozilla.pydoop.$(TASK) -libjars $(subst :,$(comma),$(HADOOP_CLASSPATH)) $(ARGS)
 
-driver.jar: out/CallJava.py $(JAVA_SOURCE)
+out/scripts:
+	mkdir -p out
+	ln -s ../scripts out/scripts
+
+driver.jar: out/scripts $(wildcard scripts/*.py) $(JAVA_SOURCE)
 	javac -Xlint:deprecation -d out  -cp $(CP) $(JAVA_SOURCE)
 	jar -cvf $@ -C out .
-
-out/CallJava.py: $(SCRIPT)
-	mkdir -p out/script
-	ln -vf $< $@
 
 %.class: ../%.java
 

--- a/org/mozilla/pydoop/HBaseDriver.java
+++ b/org/mozilla/pydoop/HBaseDriver.java
@@ -44,9 +44,9 @@ import org.python.core.PyObject;
 import org.python.core.PyIterator;
 
 public class HBaseDriver extends Configured implements Tool {
-  private PythonWrapper initPythonWrapper(String pathname)
+  private static PythonWrapper initPythonWrapper(String pathname, Job job)
   {
-    getConf().set("org.mozilla.pydoop.scriptname", pathname);    
+    job.getConfiguration().set("org.mozilla.pydoop.scriptname", pathname);
     return new PythonWrapper(pathname);
   }
 
@@ -155,7 +155,7 @@ public class HBaseDriver extends Configured implements Tool {
   public int run(String[] args) throws Exception {
     if (args.length != 6) {
       System.err.println("Usage: <script_file> <hbase_name> <out_file> yyyyMMdd(start) yyyyMMdd(stop) yyyyMMdd(format)");
-      ToolRunner.printGenericCommandUsage(System.out);
+      ToolRunner.printGenericCommandUsage(System.err);
       return -1;
     }
 
@@ -204,7 +204,11 @@ public class HBaseDriver extends Configured implements Tool {
     job.setOutputValueClass(TypeWritable.class);
     job.setSortComparatorClass(TypeWritable.Comparator.class);
 
-    PythonWrapper module = initPythonWrapper(scriptFile);
+    PythonWrapper module = initPythonWrapper(scriptFile, job);
+
+    if (!job.getConfiguration().get("org.mozilla.pydoop.scriptname").equals(scriptFile)) {
+      throw new java.lang.NullPointerException("Whoops");
+    }
 
     boolean maponly = module.getFunction("reduce") == null;
     // set below to 0 to do a map-only job

--- a/org/mozilla/pydoop/PythonWrapper.java
+++ b/org/mozilla/pydoop/PythonWrapper.java
@@ -7,6 +7,8 @@ import org.python.core.PySystemState;
 import org.python.core.Py;
 
 import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 public class PythonWrapper {
   private PythonInterpreter interp;
@@ -48,7 +50,16 @@ public class PythonWrapper {
     interp.getSystemState().path_hooks.insert(0, new JSONImporter());
 
     // Get the pathname off of the classpath
+
+    System.err.println("PythonWrapper pathname: " + pathname);
+
+    URL rurl = this.getClass().getResource("/" + pathname);
+    System.err.println("rurl: " + rurl);
+
     InputStream pythonstream = this.getClass().getResourceAsStream("/" + pathname);
+    if (null == pythonstream) {
+      throw new java.lang.NullPointerException("pythonstream");
+    }
     interp.execfile(pythonstream, pathname);
   }
   public PyObject getFunction(String name) {

--- a/org/mozilla/pydoop/PythonWrapper.java
+++ b/org/mozilla/pydoop/PythonWrapper.java
@@ -49,12 +49,7 @@ public class PythonWrapper {
     interp.getSystemState().path.insert(0, Py.newString(JSONImporter.JSON_IMPORT_PATH_ENTRY));
     interp.getSystemState().path_hooks.insert(0, new JSONImporter());
 
-    // Get the pathname off of the classpath
-
-    System.err.println("PythonWrapper pathname: " + pathname);
-
-    URL rurl = this.getClass().getResource("/" + pathname);
-    System.err.println("rurl: " + rurl);
+    // Get the the script path from our loader
 
     InputStream pythonstream = this.getClass().getResourceAsStream("/" + pathname);
     if (null == pythonstream) {


### PR DESCRIPTION
Because that way makefile dependencies don't leave you with the "wrong" CallJava.py when you change SCRIPT. And because this will allow for some cool stuff next.
