### PR TITLE
Implement HBase table and range selection as a python library `telemetryutils`

### DIFF
--- a/FileDriver.py
+++ b/FileDriver.py
@@ -27,9 +27,18 @@ def outputnokey(rlist):
         print v
 
 def map_reduce(module, fd):
+    setupfunc = getattr(module, 'setupjob', None)
+    mapfunc = getattr(module, 'map', None)
     reducefunc = getattr(module, 'reduce', None)
     combinefunc = getattr(module, 'combine', None)
-    mapfunc = getattr(module, 'map')
+
+    if setupfunc is None or not callable(setupfunc):
+        print >>sys.stderr, "Analysis script doesn't define the required function `setupjob`."
+        sys.exit(1)
+
+    if mapfunc is None or not callable(mapfunc):
+        print >>sys.stderr, "Analysis script doesn't define the required function `map`."
+        sys.exit(1)
 
     context = LocalContext(combinefunc)
 

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ Python scripts are wrapped into driver.jar with the Java driver.
 
 For example, to count the distribution of operating systems on Mozilla telemetry data for 30-March-2013, run:
 ````
-make ARGS="scripts/osdistribution.py telemetry outputfile 20130330 20133030" hadoop
+make ARGS="scripts/osdistribution.py outputfile 20130330 20133030" hadoop
 ````

--- a/org/mozilla/pydoop/HBaseDriver.java
+++ b/org/mozilla/pydoop/HBaseDriver.java
@@ -169,7 +169,7 @@ public class HBaseDriver extends Configured implements Tool {
     conf.set("mapred.map.output.compression.codec", "org.apache.hadoop.io.compress.SnappyCodec");
     FileSystem fs = FileSystem.get(conf);
 
-    String jobname = "HBaseDriver: " + StringUtils.join(args);
+    String jobname = "HBaseDriver: " + StringUtils.join(args, " ");
 
     Job job = new Job(conf, jobname);
     job.setJarByClass(HBaseDriver.class);     // class that contains mapper

--- a/scripts/anr.py
+++ b/scripts/anr.py
@@ -1,7 +1,10 @@
-#make hadoop ARGS="scripts/anr.py telemetry anr 20130313 20130313 yyyyMMdd"
+#make hadoop ARGS="scripts/anr.py anr 20130313 20130313"
 #python FileDriver.py scripts/anr.py test.data
 import sys
 import json
+import telemetryutils
+
+setupjob = telemetryutils.setupjob
 
 # This mapper is just a filter: only records which have an android hang report
 # are included in the result.

--- a/scripts/chromehangs.py
+++ b/scripts/chromehangs.py
@@ -1,5 +1,8 @@
 import sys
 import json
+import telemetryutils
+
+setupjob = telemetryutils.setupjob
 
 """Map-only script records everything with a chromehang or a late-write entry."""
 

--- a/scripts/osdistribution.py
+++ b/scripts/osdistribution.py
@@ -3,6 +3,20 @@
 import json
 import random
 import pydoop
+import telemetryutils
+
+# The setupjob function is used to set up the hadoop job correctly. In
+# almost all cases you should use telemetryutils.setupjob (or in the future
+# crashstatsutils.setupjob or healthreportutils.setupjob)
+
+setupjob = telemetryutils.setupjob
+
+# The map function is required, and is called once for each incoming record.
+# The map function may choose to call context.write(key, value) any number
+# of times.
+#
+# Keys and values are limited to None, strings, ints, floats, and tuples of
+# these primitive values.
 
 def map(k, v, cx):
     if random.random() > 0.05:

--- a/scripts/telemetryutils.py
+++ b/scripts/telemetryutils.py
@@ -1,0 +1,37 @@
+"""Utilities for querying telemetry data using pydoop."""
+
+# NOTE: When modifying this file, be careful to use java-specific imports
+# only within setupjob, so that people can test scripts using python!
+
+dateformat = 'yyyyMMdd'
+
+def setupjob(job, args):
+    """
+    Set up a job to run on telemetry date ranges.
+
+    Telemetry jobs expect two arguments, startdate and enddate, both in yyyymmdd format.
+    """
+
+    import java.text.SimpleDateFormat as SimpleDateFormat
+    import java.util.Calendar as Calendar
+    import com.mozilla.hadoop.hbase.mapreduce.MultiScanTableMapReduceUtil as MSTMRU
+    import com.mozilla.util.Pair
+    
+    if len(args) != 2:
+        raise Exception("Usage: <startdate-YYYYMMDD> <enddate-YYYYMMDD>")
+
+    sdf = SimpleDateFormat(dateformat)
+    startdate = Calendar.getInstance()
+    startdate.setTime(sdf.parse(args[0]))
+    enddate = Calendar.getInstance()
+    enddate.setTime(sdf.parse(args[1]))
+
+    print "startdate: %r enddate: %r" % (startdate, enddate)
+
+    columns = [com.mozilla.util.Pair('data', 'json')]
+    scans = MSTMRU.generateBytePrefixScans(startdate, enddate, dateformat,
+                                           columns, 500, False)
+    MSTMRU.initMultiScanTableMapperJob(
+        'telemetry',
+        scans,
+        None, None, None, job)

--- a/scripts/telemetryutils.py
+++ b/scripts/telemetryutils.py
@@ -26,8 +26,6 @@ def setupjob(job, args):
     enddate = Calendar.getInstance()
     enddate.setTime(sdf.parse(args[1]))
 
-    print "startdate: %r enddate: %r" % (startdate, enddate)
-
     columns = [com.mozilla.util.Pair('data', 'json')]
     scans = MSTMRU.generateBytePrefixScans(startdate, enddate, dateformat,
                                            columns, 500, False)


### PR DESCRIPTION
This prepares for being able to use pydoop with crash-stats and FHR as well. NOTE: this requires the change from https://github.com/mozilla-metrics/akela/pull/7, removing and re-downloading the akela jar.
