### PR TITLE
Add support for Health Report data

### DIFF
--- a/scripts/count_fhr_facets.py
+++ b/scripts/count_fhr_facets.py
@@ -1,0 +1,31 @@
+import json
+import pydoop
+import healthreportutils
+
+setupjob = healthreportutils.setupjob
+
+combine = pydoop.sumreducer
+
+def map(key, value, context):
+    try:
+        payload = json.loads(value)
+    except:
+        context.write("Bogus\tBogus\tBogus\tBogus", 1)
+        return
+
+    output = []
+    try:
+        info = payload['geckoAppInfo']
+        if type(info) == dict:
+            output.append(info['name'])
+            output.append(info['os'])
+            output.append(info['updateChannel'])
+            output.append(info['version'])
+    except KeyError:
+        pass
+
+    if len(output) == 4:
+        outkey = "\t".join(output)
+        context.write(outkey, 1)
+
+reduce = pydoop.sumreducer

--- a/scripts/healthreportutils.py
+++ b/scripts/healthreportutils.py
@@ -13,7 +13,7 @@ def setupjob(job, args):
     scan = Scan()
     scan.setCaching(500)
     scan.setCacheBlocks(False)
-    scan.addColumn('data'.getBytes(), 'json'.getBytes())
+    scan.addColumn(bytearray('data'), bytearray('json'))
 
     # FIXME: do it without this multi-scan util
     scans = [scan]

--- a/scripts/healthreportutils.py
+++ b/scripts/healthreportutils.py
@@ -1,0 +1,25 @@
+"""Utilities for querying Firefox Health Report data using jydoop."""
+
+def setupjob(job, args):
+    """
+    Set up a job to run full table scans for FHR data.
+    
+    We don't expect any arguments.
+    """
+
+    import org.apache.hadoop.hbase.client.Scan as Scan
+    import com.mozilla.hadoop.hbase.mapreduce.MultiScanTableMapReduceUtil as MSTMRU
+
+    scan = Scan()
+    scan.setCaching(500)
+    scan.setCacheBlocks(False)
+    scan.addColumn('data'.getBytes(), 'json'.getBytes())
+
+    # FIXME: do it without this multi-scan util
+    scans = [scan]
+    MSTMRU.initMultiScanTableMapperJob(
+        'metrics', scans,
+        None, None, None, job)
+
+    # inform HBaseDriver about the columns we expect to receive
+    job.getConfiguration().set("org.mozilla.pydoop.hbasecolumns", "data:json");


### PR DESCRIPTION
The HBase table for Firefox Health Report data does not use salted keys, so you do a full table scan to process the data.  This adds a utility to setup such a full table scan.

Also adds a sample FHR-processing script.
