### PR TITLE
Rename from pydoop to jydoop

### DIFF
--- a/scripts/count_fhr_facets.py
+++ b/scripts/count_fhr_facets.py
@@ -1,10 +1,10 @@
 import json
-import pydoop
+import jydoop
 import healthreportutils
 
 setupjob = healthreportutils.setupjob
 
-combine = pydoop.sumreducer
+combine = jydoop.sumreducer
 
 def map(key, value, context):
     try:
@@ -28,4 +28,4 @@ def map(key, value, context):
         outkey = "\t".join(output)
         context.write(outkey, 1)
 
-reduce = pydoop.sumreducer
+reduce = jydoop.sumreducer

--- a/scripts/healthreportutils.py
+++ b/scripts/healthreportutils.py
@@ -22,4 +22,4 @@ def setupjob(job, args):
         None, None, None, job)
 
     # inform HBaseDriver about the columns we expect to receive
-    job.getConfiguration().set("org.mozilla.pydoop.hbasecolumns", "data:json");
+    job.getConfiguration().set("org.mozilla.jydoop.hbasecolumns", "data:json");


### PR DESCRIPTION
I missed a spot where pydoop needed to change to jydoop (due to a lingering pydoop.pyc).  This fixes it.
