### PR TITLE
Added Lists, Dicts to serialization code

### DIFF
--- a/org/mozilla/jydoop/TypeWritable.java
+++ b/org/mozilla/jydoop/TypeWritable.java
@@ -10,6 +10,8 @@ import org.python.core.PyString;
 import org.python.core.PyTuple;
 import org.python.core.Py;
 import org.python.core.PyDictionary;
+import org.python.core.PyList;
+import org.python.core.PySequenceList;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -44,7 +46,8 @@ public class TypeWritable implements WritableComparable
   static final byte TYPE_STRING = 3;
   static final byte TYPE_TUPLE = 4;
   static final byte TYPE_DICT = 5;
-
+  static final byte TYPE_LIST = 6;
+  
   public PyObject value;
 
   private static void CheckType(PyObject obj)
@@ -58,8 +61,9 @@ public class TypeWritable implements WritableComparable
         obj instanceof PyString) {
       return;
     }
-    if (obj instanceof PyTuple) {
-      for (PyObject inner : ((PyTuple)obj).getArray()) {
+
+    if (obj instanceof PyList || obj instanceof PyTuple) {
+      for (PyObject inner : ((PySequenceList)obj).getArray()) {
         CheckType(inner);
       }
       return;
@@ -103,6 +107,9 @@ public class TypeWritable implements WritableComparable
     if (obj instanceof PyTuple) {
       return TYPE_TUPLE;
     }
+    if (obj instanceof PyList) {
+      return TYPE_LIST;
+    }
     if (obj instanceof PyDictionary) {
       return TYPE_DICT;
     }
@@ -132,11 +139,13 @@ public class TypeWritable implements WritableComparable
       WritableUtils.writeVInt(out, b.length);
       out.write(b);
       return;
-
     case TYPE_TUPLE:
-      WritableUtils.writeVInt(out, obj.__len__());
-      for (int i = 0; i < obj.__len__(); ++i) {
-        WriteType(out, obj.__getitem__(i));
+    case TYPE_LIST:
+      PyObject[] array = ((PySequenceList)obj).getArray();
+      WritableUtils.writeVInt(out, array.length);
+
+      for (int i = 0; i < array.length; ++i) {
+        WriteType(out, array[i]);
       }
       return;
     case TYPE_DICT:
@@ -184,12 +193,15 @@ public class TypeWritable implements WritableComparable
       in.readFully(bytes);
       return new PyString(new String(bytes, "UTF-8"));
     case TYPE_TUPLE:
+    case TYPE_LIST:
       int l = WritableUtils.readVInt(in);
       PyObject[] objs = new PyObject[l];
       for (int i = 0; i < l; ++i) {
         objs[i] = ReadObject(in);
       }
-      return new PyTuple(objs);
+      if (type == TYPE_TUPLE)
+        return new PyTuple(objs, false);
+      return new PyList(objs);
     case TYPE_DICT:
       int len = WritableUtils.readVInt(in);
       PyDictionary dict = new PyDictionary();
@@ -241,6 +253,7 @@ public class TypeWritable implements WritableComparable
       return v > 0 ? 1 : v < 0 ? -1 : 0;
 
     case TYPE_TUPLE:
+    case TYPE_LIST:
       int i = 0;
       for (; i < v1.__len__(); ++i) {
         if (i == v2.__len__()) {
@@ -392,6 +405,7 @@ public class TypeWritable implements WritableComparable
         return r > 0 ? 1 : r < 0 ? -1 : 0;
 
       case TYPE_TUPLE:
+      case TYPE_LIST:
         int l1 = v1.readVInt();
         int l2 = v2.readVInt();
         int i = 0;
@@ -407,8 +421,12 @@ public class TypeWritable implements WritableComparable
         if (i < l2) {
           return -1;
         }
+        return 0;
+      case TYPE_DICT:
+        // not sure what this method does
+        return 0;
       }
-      return 0;
+      throw new AssertionError("unhandled byte comparison");
     }
   }
 }

--- a/test.py
+++ b/test.py
@@ -78,6 +78,8 @@ class TestTypeWritable(unittest.TestCase):
         self.checkTypeWrapper((), (), 0)
         self.checkTypeWrapper((1,), (), 1)
         self.checkTypeWrapper(("foo",), ("foo",), 0)
+        self.checkTypeWrapper({'hello':1}, {'hello':1}, 0)
+        self.checkTypeWrapper({}, {}, 0)
 
 class TestResource(unittest.TestCase):
     def test_basic(self):

--- a/test.py
+++ b/test.py
@@ -46,7 +46,9 @@ class TestTypeWritable(unittest.TestCase):
 
         comp = org.mozilla.jydoop.TypeWritable.Comparator()
 
-        self.assertEqual(comp.compare(bytes1, 0, 0, bytes2, 0, 0), expected)
+        ret = comp.compare(bytes1, 0, 0, bytes2, 0, 0)
+        print [ret, expected]
+        self.assertEqual(ret, expected)
         self.assertEqual(comp.compare(bytes2, 0, 0, bytes1, 0, 0), -expected)
 
         ww1 = org.mozilla.jydoop.TypeWritable()
@@ -80,6 +82,10 @@ class TestTypeWritable(unittest.TestCase):
         self.checkTypeWrapper(("foo",), ("foo",), 0)
         self.checkTypeWrapper({'hello':1}, {'hello':1}, 0)
         self.checkTypeWrapper({}, {}, 0)
+        self.checkTypeWrapper([], [], 0)
+        self.checkTypeWrapper([1,], [], 1)
+        self.checkTypeWrapper(["foo",], ["foo",], 0)
+
 
 class TestResource(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
I did not do != 0 comparisons for dicts because that's confusing. I'm not convinced we need that.

I also did not implement byte-level dict comparison. I'm still not sure why you implemented it.

I'm still not quite sure why we need to have 1:1 mapping between sorting based on raw bytes & by higher level datastructures. The only thing that's important is that things that are equal as higher level objects remain equal as when represented as a bytestream...how they are sorted relative to other keys seems to not be important. Is there some detail I'm missing?
