### PR TITLE
Move common modules to jydoop directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,15 @@ run: driver.jar
 hadoop: driver.jar
 	time hadoop jar $< org.mozilla.jydoop.$(TASK) -libjars $(subst :,$(comma),$(HADOOP_CLASSPATH)) $(ARGS)
 
+out/pylib:
+	mkdir -p out
+	ln -s ../pylib out/pylib
+
 out/scripts:
 	mkdir -p out
 	ln -s ../scripts out/scripts
 
-driver.jar: out/scripts $(wildcard scripts/*.py) $(JAVA_SOURCE)
+driver.jar: out/scripts out/pylib $(wildcard scripts/*.py) $(wildcard pylib/*.py) $(JAVA_SOURCE)
 	javac -Xlint:deprecation -d out  -cp $(CP) $(JAVA_SOURCE)
 	jar -cvf $@ -C out .
 

--- a/pylib/crashstatsutils.py
+++ b/pylib/crashstatsutils.py
@@ -12,7 +12,7 @@ def dosetupjob(columnlist):
     Returns a setupjob function which retrieves the specified columns.
     Expects columns to be [('family', 'qualifier')...]
     """
-    
+
     def setupjob(job, args):
         """
         Set up a job to run on crash-stats date ranges.

--- a/pylib/healthreportutils.py
+++ b/pylib/healthreportutils.py
@@ -3,7 +3,7 @@
 def setupjob(job, args):
     """
     Set up a job to run full table scans for FHR data.
-    
+
     We don't expect any arguments.
     """
 

--- a/pylib/jydoop.py
+++ b/pylib/jydoop.py
@@ -5,7 +5,7 @@ Standard library of useful things for jydoop scripts.
 def isJython():
     import platform
     return platform.system() == 'Java'
-        
+
 def sumreducer(k, vlist, cx):
     """
     Simple function which can be used as a combiner and reducer to compute

--- a/pylib/telemetryutils.py
+++ b/pylib/telemetryutils.py
@@ -16,7 +16,7 @@ def setupjob(job, args):
     import java.util.Calendar as Calendar
     import com.mozilla.hadoop.hbase.mapreduce.MultiScanTableMapReduceUtil as MSTMRU
     import com.mozilla.util.Pair
-    
+
     if len(args) != 2:
         raise Exception("Usage: <startdate-YYYYMMDD> <enddate-YYYYMMDD>")
 


### PR DESCRIPTION
This is issue #29. We can now put common modules in a shared directory and they will always be available to scripts regardless of what directory the script is in.
