### PR TITLE
Allow scripts to customize the output.

### DIFF
--- a/pylib/jydoop.py
+++ b/pylib/jydoop.py
@@ -2,6 +2,8 @@
 Standard library of useful things for jydoop scripts.
 """
 
+import csv
+
 def isJython():
     import platform
     return platform.system() == 'Java'
@@ -13,10 +15,10 @@ def sumreducer(k, vlist, cx):
     """
     cx.write(k, sum(vlist))
 
-"""
-Read something out of driver.jar
-"""
 def getResource(path):
+    """
+    Read something out of driver.jar
+    """
     if isJython():
         import org.mozilla.jydoop.PythonValue as PythonValue
         import org.python.core.util.FileUtil as FileUtil
@@ -25,3 +27,46 @@ def getResource(path):
         # Python case
         f = open(path, 'r')
     return f.read()
+
+def unwrap(l, v):
+    """
+    Unwrap a value into a list. Dicts are added in their repr form.
+    """
+    if isinstance(v, (tuple, list)):
+        for e in v:
+            unwrap(l, e)
+    elif isinstance(v, dict):
+        l.append(repr(v))
+    else:
+        l.append(v)
+
+def outputWithKey(path, results):
+    """
+    Output key/values into a reasonable CSV.
+
+    All lists/tuples are unwrapped.
+    """
+
+    f = open(path, 'w')
+    w = csv.writer(f)
+    for k, v in results:
+        l = []
+        unwrap(l, k)
+        unwrap(l, v)
+        w.writerow(l)
+
+def outputWithoutKey(path, results):
+    """
+    Output values into a reasonable text file. If the values are simple,
+    they are printed directly. If they are complex tuples/lists, they are
+    printed as csv.
+    """
+    f = open(path, 'w')
+    w = csv.writer(f)
+    for k, v in results:
+        l = []
+        unwrap(l, v)
+        if len(l) == 1:
+            print >>f, v
+        else:
+            csv.writerow(l)


### PR DESCRIPTION
And make the default output a little better (use CSV if multiple values are present, otherwise just print value-per-line). Delete the temporary files off of hadoop after we've successfully completed output.
