### PR TITLE
Telemetry hdfs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,22 @@ All the different types require at least two arguments, namely the **script to
 be run** and the **filename where output will be sent**.
 
 ### Telemetry
-The production example above uses the HBase support to access Telemetry data.
 
 Telemetry jobs take two extra arguments, the **start date** and the
 **end date** of the range you want to analyze. Telemetry data is quite large,
 so it's best to keep the date range to a few days max.
+
+The production example above uses the HBase support to access Telemetry data.
+
+You may also access the most recent 14 days' data in HDFS. This will make jobs
+finish somewhat more quickly than using HBase. To use the HDFS data, specify
+the following in your script:
+```
+setupjob = telemetryutils.hdfs_setupjob
+mappertype = telemetryutils.hdfs_mappertype
+```
+
+Check the `osdistribution.hdfs.py` script for an example.
 
 ### Firefox Health Report Jobs
 

--- a/pylib/telemetryutils.py
+++ b/pylib/telemetryutils.py
@@ -1,13 +1,17 @@
 """Utilities for querying telemetry data using jydoop."""
 
 # NOTE: When modifying this file, be careful to use java-specific imports
-# only within setupjob, so that people can test scripts using python!
+#       only within setupjob, so that people can test scripts using python!
+
+# NOTE: By default we run against the data in HBase, but you may run against
+#       exported data in HDFS for improved speed by using the hdfs_* variants
+#       of the setupjob and mappertype functions.
 
 dateformat = 'yyyyMMdd'
 
 def setupjob(job, args):
     """
-    Set up a job to run on telemetry date ranges.
+    Set up a job to run on telemetry date ranges using data from HBase
 
     Telemetry jobs expect two arguments, startdate and enddate, both in yyyymmdd format.
     """
@@ -36,3 +40,72 @@ def setupjob(job, args):
 
     # inform HadoopDriver about the columns we expect to receive
     job.getConfiguration().set("org.mozilla.jydoop.hbasecolumns", "data:json");
+
+hdfs_pathformat = '/data/telemetry/%s'
+hdfs_dateformat = 'yyyy/MM/dd'
+
+def hdfs_setupjob(job, args):
+    """
+    Similar to the above, but run telemetry data that's already been exported
+    to HDFS.
+
+    Jobs expect two arguments, startdate and enddate, both in yyyyMMdd format.
+    """
+
+    import java.text.SimpleDateFormat as SimpleDateFormat
+    import java.util.Date as Date
+    import java.util.Calendar as Calendar
+    import java.util.concurrent.TimeUnit as TimeUnit
+    import com.mozilla.util.DateUtil as DateUtil
+    import com.mozilla.util.DateIterator as DateIterator
+    import org.apache.hadoop.mapreduce.lib.input.FileInputFormat as FileInputFormat
+    import org.apache.hadoop.mapreduce.lib.input.SequenceFileAsTextInputFormat as MyInputFormat
+
+    if len(args) != 2:
+        raise Exception("Usage: <startdate-YYYYMMDD> <enddate-YYYYMMDD>")
+
+    # use to collect up each date in the given range
+    class MyDateIterator(DateIterator):
+       def __init__(self):
+          self._list = []
+       def get(self):
+          return self._list
+       def see(self, aTime):
+          self._list.append(aTime)
+
+    sdf = SimpleDateFormat(dateformat)
+    sdf_hdfs = SimpleDateFormat(hdfs_dateformat)
+    startdate = Calendar.getInstance()
+    startdate.setTime(sdf.parse(args[0]))
+
+    enddate = Calendar.getInstance()
+    enddate.setTime(sdf.parse(args[1]))
+
+    nowdate = Calendar.getInstance()
+
+    # HDFS only contains the last 2 weeks of data (up to yesterday)
+    startMillis = startdate.getTimeInMillis()
+    endMillis = enddate.getTimeInMillis()
+    nowMillis = nowdate.getTimeInMillis()
+
+    startDiff = nowMillis - startMillis
+    if TimeUnit.DAYS.convert(startDiff, TimeUnit.MILLISECONDS) > 14:
+        raise Exception("HDFS Data only includes the past 14 days of history. Try again with more recent dates or use the HBase data directly.")
+
+    endDiff = nowMillis - endMillis
+    if TimeUnit.DAYS.convert(endDiff, TimeUnit.MILLISECONDS) < 1:
+        raise Exception("HDFS Data only includes data up to yesterday. For (partial) data for today, use the HBase data directly.")
+
+    dates = MyDateIterator()
+
+    DateUtil.iterateByDay(startMillis, endMillis, dates)
+
+    paths = []
+    for d in dates.get():
+       paths.append(hdfs_pathformat % (sdf_hdfs.format(Date(d))))
+
+    job.setInputFormatClass(MyInputFormat)
+    FileInputFormat.setInputPaths(job, ",".join(paths));
+
+def hdfs_mappertype():
+    return "TEXT"

--- a/scripts/osdistribution.hdfs.py
+++ b/scripts/osdistribution.hdfs.py
@@ -1,0 +1,47 @@
+# mapreduce job to count the distribution of OS data using the Telemetry
+# data that is exported from HBase -> HDFS.  This script is intentionally
+# similar to osdistribution.py for comparison purposes.
+
+import json
+import random
+import jydoop
+import telemetryutils
+
+# The setupjob function is used to set up the hadoop job correctly. In
+# almost all cases you should use telemetryutils.setupjob (or in the future
+# crashstatsutils.setupjob or healthreportutils.setupjob)
+
+setupjob = telemetryutils.hdfs_setupjob
+
+mappertype = telemetryutils.hdfs_mappertype
+
+# The map function is required, and is called once for each incoming record.
+# The map function may choose to call context.write(key, value) any number
+# of times.
+#
+# Keys and values are limited to None, strings, ints, floats, and tuples of
+# these primitive values.
+
+def map(k, v, cx):
+    if random.random() > 0.05:
+        return
+    j = json.loads(v)
+    os = j['info']['OS']
+    cx.write(os, 1)
+
+# Combining happens on each map node, and is called with an arbitrary number
+# map records which have the same key. The combiner, if present, should output
+# a record of the same "schema" as the map function does.
+#
+# In this case, we combine the records by counting the records.
+
+combine = jydoop.sumreducer
+
+# After all of the map records for a particular key have been
+# collected, reduction can count or combine these records (it could
+# e.g. produce a histogram or some other complex structure).
+# 
+# In this case, reduction is the exact same as combining, it just adds
+# the map and/or combine results together.
+
+reduce = jydoop.sumreducer


### PR DESCRIPTION
Add support for reading Telemetry data from HDFS (Sequence Files) instead of scanning HBase. This is now the preferred way to access Telemetry data for the most recent 2 weeks.  You'll get an error message if you try to run on data outside that time frame.
