### PR TITLE
Use the HDFS data for telemetry jobs by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Telemetry jobs take two extra arguments, the **start date** and the
 **end date** of the range you want to analyze. Telemetry data is quite large,
 so it's best to keep the date range to a few days max.
 
-The production example above uses the HBase support to access Telemetry data.
+The production example above uses the HBase support to access Telemetry data
+(using the `telemetryutils.hbase_setupjob` setup function).
 
 You may also access the most recent 14 days' data in HDFS. This will make jobs
 finish somewhat more quickly than using HBase. To use the HDFS data, specify
 the following in your script:
 ```
-setupjob = telemetryutils.hdfs_setupjob
-mappertype = telemetryutils.hdfs_mappertype
+setupjob = telemetryutils.setupjob
 ```
 
 Check the `osdistribution.hdfs.py` script for an example.

--- a/pylib/telemetryutils.py
+++ b/pylib/telemetryutils.py
@@ -3,13 +3,13 @@
 # NOTE: When modifying this file, be careful to use java-specific imports
 #       only within setupjob, so that people can test scripts using python!
 
-# NOTE: By default we run against the data in HBase, but you may run against
-#       exported data in HDFS for improved speed by using the hdfs_* variants
-#       of the setupjob and mappertype functions.
+# NOTE: By default we run against the data in HDFS, but you may run against
+#       the raw data in HBase if you need to access data older than 14 days.
+#       To access HBase, use the 'hbase_setupjob' function.
 
 dateformat = 'yyyyMMdd'
 
-def setupjob(job, args):
+def hbase_setupjob(job, args):
     """
     Set up a job to run on telemetry date ranges using data from HBase
 
@@ -44,7 +44,7 @@ def setupjob(job, args):
 hdfs_pathformat = '/data/telemetry/%s'
 hdfs_dateformat = 'yyyy/MM/dd'
 
-def hdfs_setupjob(job, args):
+def setupjob(job, args):
     """
     Similar to the above, but run telemetry data that's already been exported
     to HDFS.
@@ -106,6 +106,4 @@ def hdfs_setupjob(job, args):
 
     job.setInputFormatClass(MyInputFormat)
     FileInputFormat.setInputPaths(job, ",".join(paths));
-
-def hdfs_mappertype():
-    return "TEXT"
+    job.getConfiguration().set("org.mozilla.jydoop.mappertype", "TEXT")

--- a/scripts/osdistribution.hdfs.py
+++ b/scripts/osdistribution.hdfs.py
@@ -11,9 +11,7 @@ import telemetryutils
 # almost all cases you should use telemetryutils.setupjob (or in the future
 # crashstatsutils.setupjob or healthreportutils.setupjob)
 
-setupjob = telemetryutils.hdfs_setupjob
-
-mappertype = telemetryutils.hdfs_mappertype
+setupjob = telemetryutils.setupjob
 
 # The map function is required, and is called once for each incoming record.
 # The map function may choose to call context.write(key, value) any number

--- a/scripts/osdistribution.py
+++ b/scripts/osdistribution.py
@@ -9,7 +9,7 @@ import telemetryutils
 # almost all cases you should use telemetryutils.setupjob (or in the future
 # crashstatsutils.setupjob or healthreportutils.setupjob)
 
-setupjob = telemetryutils.setupjob
+setupjob = telemetryutils.hbase_setupjob
 
 # The map function is required, and is called once for each incoming record.
 # The map function may choose to call context.write(key, value) any number


### PR DESCRIPTION
Now that 'mappertype' is part of the job setup instead of a separate function, we can switch the default for Telemetry to HDFS without affecting existing scripts.

This is desirable because jobs run faster and produce less load on the cluster compared to using HBase.
