### PR TITLE
Expose HBase timestamps to the map function

### DIFF
--- a/org/mozilla/jydoop/HadoopDriver.java
+++ b/org/mozilla/jydoop/HadoopDriver.java
@@ -85,6 +85,11 @@ public class HadoopDriver extends Configured implements Tool {
       cx.write(new PythonKey(key), new PythonValue(val));
     }
 
+    public Configuration getConfiguration()
+    {
+      return cx.getConfiguration();
+    }
+
     public Counter getCounter(String groupName, String counterName)
     {
       return cx.getCounter(groupName, counterName);

--- a/org/mozilla/jydoop/HadoopDriver.java
+++ b/org/mozilla/jydoop/HadoopDriver.java
@@ -95,6 +95,7 @@ public class HadoopDriver extends Configured implements Tool {
     private PyObject mapfunc;
     private PyObject contextobj;
     private PythonWrapper pwrapper;
+    private boolean includeTimestamp;
 
     private static class ColumnID
     {
@@ -123,7 +124,9 @@ public class HadoopDriver extends Configured implements Tool {
 
       // should be family:qualifier[,family:qualifier...]
 
-      String[] columns = context.getConfiguration().get("org.mozilla.jydoop.hbasecolumns").split(",");
+      Configuration conf = context.getConfiguration();
+      String[] columns = conf.get("org.mozilla.jydoop.hbasecolumns").split(",");
+      includeTimestamp = conf.getBoolean("org.mozilla.jydoop.include_row_timestamp", false);
 
       columnlist = new ColumnID[columns.length];
       for (int i = 0; i < columns.length; ++i) {
@@ -146,11 +149,21 @@ public class HadoopDriver extends Configured implements Tool {
 
     public void map(ImmutableBytesWritable key, Result value, Context context) throws IOException, InterruptedException {
 
-      // map(k, column1, [column2, ...], context)
+      // map(k, column1, [column2, ...], [timestamp], context)
+      int argcount = 2 + columnlist.length;
 
-      PyObject[] args = new PyObject[2 + columnlist.length];
+      if (includeTimestamp) {
+          argcount += 1;
+      }
+      PyObject[] args = new PyObject[argcount];
       args[0] = Py.newString(StringUtil.fromBytes(key.get()));
       args[args.length - 1] = contextobj;
+      if (includeTimestamp) {
+          // TODO: change to this when we move to HBase 0.96+:
+          // Cell cell = value.getColumnLatestCell();
+          // args[args.length - 2] = cell == null ? Py.None : Py.newLong(cell.getTimestamp());
+          args[args.length - 2] = Py.newLong(value.raw()[0].getTimestamp());
+      }
       for (int i = 0; i < columnlist.length; ++i) {
         byte[] vbytes = value.getValue(columnlist[i].family, columnlist[i].qualifier);
         args[i + 1] = vbytes == null ? Py.None : Py.newString(StringUtil.fromBytes(vbytes));
@@ -336,7 +349,6 @@ public class HadoopDriver extends Configured implements Tool {
        job.setMapperClass(JydoopMapper.class);
        break;
     default:
-       // TODO: Warn?
        // Default to HBaseMapper
        job.setMapperClass(HBaseMapper.class);
        break;

--- a/pylib/hbaseutils.py
+++ b/pylib/hbaseutils.py
@@ -1,0 +1,23 @@
+def setup_full_scan_job(table, job, args):
+    """
+    Set up a job to run full HBase table scans.
+
+    We don't expect any extra args.
+    """
+
+    import org.apache.hadoop.hbase.client.Scan as Scan
+    import com.mozilla.hadoop.hbase.mapreduce.MultiScanTableMapReduceUtil as MSTMRU
+
+    scan = Scan()
+    scan.setCaching(500)
+    scan.setCacheBlocks(False)
+    scan.addColumn(bytearray('data'), bytearray('json'))
+
+    # FIXME: do it without this multi-scan util
+    scans = [scan]
+    MSTMRU.initMultiScanTableMapperJob(
+        table, scans,
+        None, None, None, job)
+
+    # inform HadoopDriver about the columns we expect to receive
+    job.getConfiguration().set("org.mozilla.jydoop.hbasecolumns", "data:json");

--- a/scripts/userprofile.py
+++ b/scripts/userprofile.py
@@ -1,0 +1,30 @@
+"""
+UserProfile a.k.a. User Personalization is a feature of firefox in development.
+
+It is an API we are implementing that exposes a user's interests based on their
+browsing patterns, with user opt-in.
+
+This script dumps the data collected via a TestPilot study, submitted to
+data.mozilla.com
+"""
+import re
+import hbaseutils
+
+NOOP_PATTERN = re.compile("no-?op")
+
+def setupjob(job, args):
+    """
+    Set up a job to run full table scans for UserProfile data.
+
+    We don't expect any arguments.
+    """
+    hbaseutils.setup_full_scan_job("user_profile", job, args)
+
+    # inform HadoopDriver about the columns we expect to receive
+    job.getConfiguration().set("org.mozilla.jydoop.hbasecolumns", "data:json")
+    job.getConfiguration().set("org.mozilla.jydoop.include_row_timestamp", "true")
+
+def map(key, value, timestamp, context):
+    if not NOOP_PATTERN.search(value):
+        output = "[{0},{1}]".format(value,timestamp)
+        context.write(timestamp,output)


### PR DESCRIPTION
This also adds an hbase-specific setup helper function to reduce the amount of boilerplate required to set up an hbase scan.

As a minimal example:

```
import hbaseutils

def setupjob(job, args):
    hbaseutils.setup_full_scan_job("user_profile", job, args)
    job.getConfiguration().set("org.mozilla.jydoop.include_row_timestamp", "true")

def map(key, value, ts, cx):
    cx.write(key, ts)
```
