### PR TITLE
typo fix; per-script number of reducers

### DIFF
--- a/org/mozilla/jydoop/HadoopDriver.java
+++ b/org/mozilla/jydoop/HadoopDriver.java
@@ -343,8 +343,17 @@ public class HadoopDriver extends Configured implements Tool {
     }
 
     boolean maponly = module.getFunction("reduce") == null;
+
+    int numReducers = 4; //use 4 as the default, but
+    // See if we want to set a specific number of reduce tasks
+    System.out.println("check for num_reduce_tasks()");
+    PyObject numReducersFnc = module.getFunction("num_reduce_tasks");
+    if (numReducersFnc != null) {
+      PyObject numReducersPy = numReducersFnc.__call__();
+      numReducers = numReducersPy.asInt();
+    }
     // set below to 0 to do a map-only job
-    job.setNumReduceTasks(maponly ? 0 : 4 );    // at least one, adjust as required
+    job.setNumReduceTasks(maponly ? 0 : numReducers );    // at least one, adjust as required
 
     if (module.getFunction("combine") != null) {
       job.setCombinerClass(MyCombiner.class);
@@ -359,7 +368,7 @@ public class HadoopDriver extends Configured implements Tool {
     if (skipfunc != null) {
        PyObject skipobj = skipfunc.__call__();
        if (skipobj.asInt() != 0) {
-          return 0;
+          return 0; //this exits run(), skipping the local output parts below
        }
     }
 

--- a/pylib/healthreportutils.py
+++ b/pylib/healthreportutils.py
@@ -23,7 +23,7 @@ from collections import namedtuple
 SessionInfo = namedtuple('SessionInfo', ('total', 'clean', 'active_ticks'))
 
 
-SessionStartTimes = namedtuple('SessionStartTimes', ('main', 'first_pain',
+SessionStartTimes = namedtuple('SessionStartTimes', ('main', 'first_paint',
     'session_restored'))
 
 


### PR DESCRIPTION
Fixed a typo in healthreportutils.py.

Added the ability to set a custom number of reducers by defining a function "num_reduce_tasks" in your script. Ex:
def num_reduce_tasks():
    return 23
There may be a better way to do this; I copied the approach from "skip_local_output". But it Works Today, so there's that...

Extended the functionality that mreid added for counters to local jobs run with FileDriver.py. There's probably a better way to do this too, but this also works fine.
